### PR TITLE
Add semver and arm64 to container build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,11 +27,17 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker Meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: |
             ghcr.io/scilifelabdatacentre/url-forwarder
-            scilifelabdatacentre/url-forwarder
+            docker.io/scilifelabdatacentre/url-forwarder
+          tags: |
+            type=sha,format=long
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
       - name: Build and Publish
         uses: docker/build-push-action@v2
         with:
@@ -40,3 +46,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
* tag container images with semantic versioning

* build arm64 in addition to amd64

* bump docker/metadata-action to v4

* base tagging on git tags vX.Y.Z instead o release (published)

Signed-off-by: Erik Sjölund <erik.sjolund@scilifelab.uu.se>